### PR TITLE
Develop/metrics add bytes counter

### DIFF
--- a/src/main/java/com/kiwi/exception/ResponseWritingException.java
+++ b/src/main/java/com/kiwi/exception/ResponseWritingException.java
@@ -1,0 +1,7 @@
+package com.kiwi.exception;
+
+public class ResponseWritingException extends RuntimeException {
+    public ResponseWritingException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/kiwi/observability/MetricsRegistry.java
+++ b/src/main/java/com/kiwi/observability/MetricsRegistry.java
@@ -5,27 +5,29 @@ import java.util.concurrent.atomic.LongAdder;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-public final class Metrics {
-    private static final Logger logger = Logger.getLogger(Metrics.class.getName());
-    private static final Metrics instance = new Metrics();
+final class MetricsRegistry {
+    private static final Logger logger = Logger.getLogger(MetricsRegistry.class.getName());
+    private static final MetricsRegistry instance = new MetricsRegistry();
 
     private final AtomicLong clientsCurrent = new AtomicLong(0);
     private final LongAdder connectionsAccepted = new LongAdder();
     private final LongAdder connectionsClosed = new LongAdder();
+    private final LongAdder bytesIn = new LongAdder();
+    private final LongAdder bytesOut = new LongAdder();
 
-    public static Metrics getInstance() {
+    public static MetricsRegistry getInstance() {
         return instance;
     }
 
-    private Metrics() {
+    private MetricsRegistry() {
     }
 
-    public void addConnectionAccepted() {
+    public void addAcceptConnection() {
         connectionsAccepted.increment();
         clientsCurrent.incrementAndGet();
     }
 
-    public void addConnectionsClosed() {
+    public void addCloseConnection() {
         connectionsClosed.increment();
         final var currentClients = clientsCurrent.decrementAndGet();
         if (currentClients < 0) {
@@ -33,6 +35,14 @@ public final class Metrics {
                 + ", reset to 0");
             clientsCurrent.set(0);
         }
+    }
+
+    public void addParsedBytes(long bytesIn) {
+        this.bytesIn.add(bytesIn);
+    }
+
+    public void addWrittenBytes(long bytesOut) {
+        this.bytesOut.add(bytesOut);
     }
 
     public long getAcceptedConnections() {
@@ -45,5 +55,13 @@ public final class Metrics {
 
     public long getCurrentClients() {
         return clientsCurrent.get();
+    }
+
+    public long getBytesIn() {
+        return bytesIn.sum();
+    }
+
+    public long getBytesOut() {
+        return bytesOut.sum();
     }
 }

--- a/src/main/java/com/kiwi/observability/ObservabilityModule.java
+++ b/src/main/java/com/kiwi/observability/ObservabilityModule.java
@@ -1,11 +1,12 @@
 package com.kiwi.observability;
 
 public class ObservabilityModule {
-    public static Metrics getMetrics() {
-        return Metrics.getInstance();
-    }
 
     public static ObservabilityRequestHandler getRequestHandler() {
-        return new ObservabilityRequestHandler(getMetrics());
+        return new ObservabilityRequestHandler(MetricsRegistry.getInstance());
+    }
+
+    public static RequestMetrics getRequestMetrics() {
+        return new RequestMetrics(MetricsRegistry.getInstance());
     }
 }

--- a/src/main/java/com/kiwi/observability/ObservabilityRequestHandler.java
+++ b/src/main/java/com/kiwi/observability/ObservabilityRequestHandler.java
@@ -3,7 +3,7 @@ package com.kiwi.observability;
 import com.kiwi.observability.dto.MetricsDataDto;
 
 public class ObservabilityRequestHandler {
-    public ObservabilityRequestHandler(MetricsRegistry metricsRegistry) {
+    ObservabilityRequestHandler(MetricsRegistry metricsRegistry) {
         this.metricsRegistry = metricsRegistry;
     }
 

--- a/src/main/java/com/kiwi/observability/ObservabilityRequestHandler.java
+++ b/src/main/java/com/kiwi/observability/ObservabilityRequestHandler.java
@@ -3,14 +3,19 @@ package com.kiwi.observability;
 import com.kiwi.observability.dto.MetricsDataDto;
 
 public class ObservabilityRequestHandler {
-    public ObservabilityRequestHandler(Metrics metrics) {
-        this.metrics = metrics;
+    public ObservabilityRequestHandler(MetricsRegistry metricsRegistry) {
+        this.metricsRegistry = metricsRegistry;
     }
 
-    private final Metrics metrics;
+    private final MetricsRegistry metricsRegistry;
 
     public MetricsDataDto getMetricsInfo() {
-        return new MetricsDataDto(metrics.getAcceptedConnections(),
-            metrics.getClosedConnections(), metrics.getCurrentClients());
+        return new MetricsDataDto(
+            metricsRegistry.getAcceptedConnections(),
+            metricsRegistry.getClosedConnections(),
+            metricsRegistry.getCurrentClients(),
+            metricsRegistry.getBytesIn(),
+            metricsRegistry.getBytesOut()
+        );
     }
 }

--- a/src/main/java/com/kiwi/observability/RequestMetrics.java
+++ b/src/main/java/com/kiwi/observability/RequestMetrics.java
@@ -3,7 +3,7 @@ package com.kiwi.observability;
 public final class RequestMetrics {
     private final MetricsRegistry metricsRegistry;
 
-    public RequestMetrics(MetricsRegistry metricsRegistry) {
+    RequestMetrics(MetricsRegistry metricsRegistry) {
         this.metricsRegistry = metricsRegistry;
     }
 

--- a/src/main/java/com/kiwi/observability/RequestMetrics.java
+++ b/src/main/java/com/kiwi/observability/RequestMetrics.java
@@ -1,0 +1,25 @@
+package com.kiwi.observability;
+
+public final class RequestMetrics {
+    private final MetricsRegistry metricsRegistry;
+
+    public RequestMetrics(MetricsRegistry metricsRegistry) {
+        this.metricsRegistry = metricsRegistry;
+    }
+
+    public void onAccept() {
+        metricsRegistry.addAcceptConnection();
+    }
+
+    public void onClose() {
+        metricsRegistry.addCloseConnection();
+    }
+
+    public void onParse(long bytes) {
+        metricsRegistry.addParsedBytes(bytes);
+    }
+
+    public void onWrite(long bytes) {
+        metricsRegistry.addWrittenBytes(bytes);
+    }
+}

--- a/src/main/java/com/kiwi/observability/dto/MetricsDataDto.java
+++ b/src/main/java/com/kiwi/observability/dto/MetricsDataDto.java
@@ -3,6 +3,8 @@ package com.kiwi.observability.dto;
 public record MetricsDataDto(
     long acceptedConnections,
     long closedConnections,
-    long currentClients
+    long currentClients,
+    long bytesIn,
+    long bytesOut
 ) {
 }

--- a/src/main/java/com/kiwi/server/InputStreamWrapper.java
+++ b/src/main/java/com/kiwi/server/InputStreamWrapper.java
@@ -9,6 +9,7 @@ public class InputStreamWrapper {
     private static final Logger log = Logger.getLogger(InputStreamWrapper.class.getName());
 
     private final InputStream inputStream;
+    private int counter = 0;
 
     public InputStreamWrapper(InputStream inputStream) {
         this.inputStream = inputStream;
@@ -16,7 +17,11 @@ public class InputStreamWrapper {
 
     public int read() {
         try {
-            return inputStream.read();
+            final int b = inputStream.read();
+            if (b != -1) {
+                counter++;
+            }
+            return b;
         } catch (IOException e) {
             log.severe("Unexpected exception during read input stream" + e.getMessage());
             throw new UncheckedIOException("Unexpected exception during read input stream");
@@ -25,10 +30,16 @@ public class InputStreamWrapper {
 
     public byte[] readNBytes(int len) {
         try {
-            return inputStream.readNBytes(len);
+            final byte[] bs = inputStream.readNBytes(len);
+            counter += bs.length;
+            return bs;
         } catch (IOException e) {
             log.severe("Unexpected exception during read input stream" + e.getMessage());
             throw new UncheckedIOException("Unexpected exception during read input stream");
         }
+    }
+
+    public int getCounter() {
+        return counter;
     }
 }

--- a/src/main/java/com/kiwi/server/RequestDispatcher.java
+++ b/src/main/java/com/kiwi/server/RequestDispatcher.java
@@ -3,8 +3,8 @@ package com.kiwi.server;
 import static com.kiwi.server.util.ServerConstants.OK_MESSAGE;
 
 import com.kiwi.dto.DataRequest;
-import com.kiwi.dto.TCPRequest;
-import com.kiwi.dto.TCPResponse;
+import com.kiwi.server.dto.TCPRequest;
+import com.kiwi.server.dto.TCPResponse;
 import com.kiwi.exception.UnknownMethodException;
 import com.kiwi.observability.ObservabilityRequestHandler;
 import com.kiwi.processor.DataProcessor;

--- a/src/main/java/com/kiwi/server/RequestParser.java
+++ b/src/main/java/com/kiwi/server/RequestParser.java
@@ -1,11 +1,9 @@
 package com.kiwi.server;
 
-import static com.kiwi.server.Method.EXT;
 import static com.kiwi.server.Method.SET;
-import static com.kiwi.server.Method.UNKNOWN;
 import static com.kiwi.server.util.ServerConstants.SEPARATOR;
 
-import com.kiwi.dto.TCPRequest;
+import com.kiwi.server.dto.TCPRequest;
 import com.kiwi.exception.ProtocolException;
 import com.kiwi.persistent.dto.Key;
 import com.kiwi.persistent.dto.Value;
@@ -27,10 +25,11 @@ public class RequestParser {
             return new TCPRequest(method);
         }
 
+        final var key = getKey(is);
         if (SET.equals(method)) {
-            return new TCPRequest(method, getKey(is), getValue(is));
+            return new TCPRequest(method, key, getValue(is));
         } else {
-            return new TCPRequest(method, getKey(is));
+            return new TCPRequest(method, key);
         }
     }
 

--- a/src/main/java/com/kiwi/server/ResponseWriter.java
+++ b/src/main/java/com/kiwi/server/ResponseWriter.java
@@ -4,6 +4,7 @@ import static com.kiwi.server.util.ServerConstants.ERROR_PREFIX;
 import static com.kiwi.server.util.ServerConstants.SEPARATOR;
 import static com.kiwi.server.util.ServerConstants.SUCCESS_PREFIX;
 
+import com.kiwi.exception.ResponseWritingException;
 import com.kiwi.server.dto.TCPResponse;
 import com.kiwi.server.dto.WriteResponseResult;
 import java.io.ByteArrayOutputStream;
@@ -50,6 +51,8 @@ public class ResponseWriter {
         } catch (Exception ex) {
             log.severe("Unexpected exception during writing response to output stream: "
                 + ex.getMessage());
+            throw new ResponseWritingException("Unexpected exception during writing response to "
+            + "output stream");
         }
     }
 

--- a/src/main/java/com/kiwi/server/ResponseWriter.java
+++ b/src/main/java/com/kiwi/server/ResponseWriter.java
@@ -4,7 +4,8 @@ import static com.kiwi.server.util.ServerConstants.ERROR_PREFIX;
 import static com.kiwi.server.util.ServerConstants.SEPARATOR;
 import static com.kiwi.server.util.ServerConstants.SUCCESS_PREFIX;
 
-import com.kiwi.dto.TCPResponse;
+import com.kiwi.server.dto.TCPResponse;
+import com.kiwi.server.dto.WriteResponseResult;
 import java.io.ByteArrayOutputStream;
 import java.net.Socket;
 import java.nio.charset.StandardCharsets;
@@ -13,12 +14,13 @@ import java.util.logging.Logger;
 public class ResponseWriter {
     private static final Logger log = Logger.getLogger(ResponseWriter.class.getSimpleName());
 
-    public void writeResponse(Socket socket, TCPResponse tcpResponse) {
+    public WriteResponseResult writeResponse(Socket socket, TCPResponse tcpResponse) {
         final var prefix = tcpResponse.isSuccess() ? SUCCESS_PREFIX : ERROR_PREFIX;
         final var baos = new ByteArrayOutputStream();
         writeToBaos(baos, prefix, tcpResponse);
 
         writeToOs(socket, baos);
+        return new WriteResponseResult(baos.size());
     }
 
     private void writeToBaos(ByteArrayOutputStream baos, byte prefix, TCPResponse tcpResponse) {

--- a/src/main/java/com/kiwi/server/dto/TCPRequest.java
+++ b/src/main/java/com/kiwi/server/dto/TCPRequest.java
@@ -1,4 +1,4 @@
-package com.kiwi.dto;
+package com.kiwi.server.dto;
 
 import com.kiwi.persistent.dto.Key;
 import com.kiwi.persistent.dto.Value;

--- a/src/main/java/com/kiwi/server/dto/TCPResponse.java
+++ b/src/main/java/com/kiwi/server/dto/TCPResponse.java
@@ -1,4 +1,4 @@
-package com.kiwi.dto;
+package com.kiwi.server.dto;
 
 import com.kiwi.server.response.SerializableValue;
 

--- a/src/main/java/com/kiwi/server/dto/WriteResponseResult.java
+++ b/src/main/java/com/kiwi/server/dto/WriteResponseResult.java
@@ -1,0 +1,6 @@
+package com.kiwi.server.dto;
+
+public record WriteResponseResult(
+    int writtenBytes
+) {
+}

--- a/src/main/java/com/kiwi/server/factory/ServerModule.java
+++ b/src/main/java/com/kiwi/server/factory/ServerModule.java
@@ -14,7 +14,7 @@ public class ServerModule {
         final var observabilityRequestHandler = ObservabilityModule.getRequestHandler();
         final var dispatcher = new RequestDispatcher(dataProcessor, observabilityRequestHandler);
         final var responseWriter = new ResponseWriter();
-        final var metrics = ObservabilityModule.getMetrics();
+        final var metrics = ObservabilityModule.getRequestMetrics();
         final var handler = new RequestHandler(dispatcher, parser, responseWriter, metrics);
         return new TCPServer(handler);
     }

--- a/src/main/java/com/kiwi/server/response/ObservabilityResponse.java
+++ b/src/main/java/com/kiwi/server/response/ObservabilityResponse.java
@@ -8,19 +8,18 @@ public record ObservabilityResponse(
 ) implements SerializableValue {
     @Override
     public byte[] serialize() {
-        return new StringBuilder("{ ")
-            .append("\"acceptedConnections\": ")
-            .append(metrics.acceptedConnections())
-            .append(", \"closedConnections\": ")
-            .append(metrics.closedConnections())
-            .append(", \"currentClients\": ")
-            .append(metrics.currentClients())
-            .append(", \"bytesIn\": ")
-            .append(metrics.bytesIn())
-            .append(", \"bytesOut\": ")
-            .append(metrics.bytesOut())
-            .append(" }")
-            .toString()
+        return ("{ " +
+            "\"acceptedConnections\": " +
+            metrics.acceptedConnections() +
+            ", \"closedConnections\": " +
+            metrics.closedConnections() +
+            ", \"currentClients\": " +
+            metrics.currentClients() +
+            ", \"bytesIn\": " +
+            metrics.bytesIn() +
+            ", \"bytesOut\": " +
+            metrics.bytesOut() +
+            " }")
             .getBytes(StandardCharsets.UTF_8);
     }
 }

--- a/src/main/java/com/kiwi/server/response/ObservabilityResponse.java
+++ b/src/main/java/com/kiwi/server/response/ObservabilityResponse.java
@@ -8,14 +8,19 @@ public record ObservabilityResponse(
 ) implements SerializableValue {
     @Override
     public byte[] serialize() {
-        final var sb = new StringBuilder("{ ");
-        sb.append("\"acceptedConnections\": ");
-        sb.append(metrics.acceptedConnections());
-        sb.append(", \"closedConnections\": ");
-        sb.append(metrics.closedConnections());
-        sb.append(", \"currentClients\": ");
-        sb.append(metrics.currentClients());
-        sb.append(" }");
-        return sb.toString().getBytes(StandardCharsets.UTF_8);
+        return new StringBuilder("{ ")
+            .append("\"acceptedConnections\": ")
+            .append(metrics.acceptedConnections())
+            .append(", \"closedConnections\": ")
+            .append(metrics.closedConnections())
+            .append(", \"currentClients\": ")
+            .append(metrics.currentClients())
+            .append(", \"bytesIn\": ")
+            .append(metrics.bytesIn())
+            .append(", \"bytesOut\": ")
+            .append(metrics.bytesOut())
+            .append(" }")
+            .toString()
+            .getBytes(StandardCharsets.UTF_8);
     }
 }


### PR DESCRIPTION
Scope:
Added two process-wide counters to Metrics: bytesIn and bytesOut. Extended INF output to include both fields.

Why:
Measure actual protocol traffic to validate framing correctness and observe throughput. Counters are monotonic since start.

Details:
bytesIn increments after a request is fully parsed and accepted; it includes the entire protocol frame (verb, arguments, delimiters).
bytesOut increments after the response has been fully written to the socket; it includes the entire response frame (OK/error plus framing).
The first INF after startup can show bytesOut=0 for its own response because counting occurs only after a successful write completes.

INF example (fields appended):
{ ..., "bytesIn": <n>, "bytesOut": <n> }

Manual verification:
Send a known request and confirm bytesIn equals the framed request size and bytesOut equals the response size.
Send multiple requests on one connection and verify totals increase additively.
Trigger a parse error and confirm bytesIn does not increase (only valid frames are counted).
Abort mid-response and confirm bytesOut remains unchanged (all-or-nothing policy).

@codex review