### PR TITLE
develop/metrics -> add server time work

### DIFF
--- a/src/main/java/com/kiwi/observability/MetricsRegistry.java
+++ b/src/main/java/com/kiwi/observability/MetricsRegistry.java
@@ -13,6 +13,7 @@ final class MetricsRegistry {
     private final BytesCounter bytesCounter = new BytesCounter();
     private final MethodCounter methodCounter = new MethodCounter();
     private final ProtoErrorCounter protoErrorCounter = new ProtoErrorCounter();
+    private final ServerCounters serverCounters = new ServerCounters();
 
     public static MetricsRegistry getInstance() {
         return instance;
@@ -157,6 +158,10 @@ final class MetricsRegistry {
         return protoErrorCounter.invalidSeparatorCounter.sum();
     }
 
+    public long getServerStart() {
+        return serverCounters.startUpMillis;
+    }
+
     private static class MethodCounter {
         private final LongAdder getCounter = new LongAdder();
         private final LongAdder setCounter = new LongAdder();
@@ -260,5 +265,9 @@ final class MetricsRegistry {
         private void onInvalidSeparator() {
             invalidSeparatorCounter.increment();
         }
+    }
+
+    private static class ServerCounters {
+        private final long startUpMillis = System.currentTimeMillis();
     }
 }

--- a/src/main/java/com/kiwi/observability/ObservabilityRequestHandler.java
+++ b/src/main/java/com/kiwi/observability/ObservabilityRequestHandler.java
@@ -27,7 +27,9 @@ public class ObservabilityRequestHandler {
             metricsRegistry.getKeyTooLong(),
             metricsRegistry.getUnexpectedEndOfFile(),
             metricsRegistry.getNonDigitInLength(),
-            metricsRegistry.getInvalidSeparator()
+            metricsRegistry.getInvalidSeparator(),
+            metricsRegistry.getServerStart(),
+            System.currentTimeMillis() - metricsRegistry.getServerStart()
         );
     }
 }

--- a/src/main/java/com/kiwi/observability/dto/MetricsDataDto.java
+++ b/src/main/java/com/kiwi/observability/dto/MetricsDataDto.java
@@ -17,6 +17,8 @@ public record MetricsDataDto(
     long keyTooLong,
     long unexpectedEndOfFile,
     long nonDigitInLength,
-    long invalidSeparator
+    long invalidSeparator,
+    long serverStart,
+    long serverUptime
 ) {
 }

--- a/src/main/java/com/kiwi/server/response/ObservabilityResponse.java
+++ b/src/main/java/com/kiwi/server/response/ObservabilityResponse.java
@@ -43,6 +43,10 @@ public record ObservabilityResponse(
             metrics.nonDigitInLength() +
             ", \"proto.err.invalidseparator\": " +
             metrics.invalidSeparator() +
+            ", \"server.start\": " +
+            metrics.serverStart() +
+            ", \"server.uptime\": " +
+            metrics.serverUptime() +
             " }")
             .getBytes(StandardCharsets.UTF_8);
     }


### PR DESCRIPTION
PR: Add server start time and uptime to INF

Description:
Capture serverStartMillis at bootstrap and expose it in INF along with a computed uptimeMillis (now − start). No other schema changes. Enables quick sanity checks and correlating metrics over process lifetime.

Scope:
Initialize start timestamp during server startup; INF renderer appends serverStartMillis and uptimeMillis. Counters/gauges unchanged.
