### PR TITLE
develop/metrics -> add refused connection counter

### DIFF
--- a/src/main/java/com/kiwi/observability/MetricsRegistry.java
+++ b/src/main/java/com/kiwi/observability/MetricsRegistry.java
@@ -30,6 +30,10 @@ final class MetricsRegistry {
         connectionCounter.onClosed();
     }
 
+    public void addRefusedConnection() {
+        connectionCounter.onRefused();
+    }
+
     public void addParsedBytes(long bytesIn) {
         this.bytesCounter.onBytesIn(bytesIn);
     }
@@ -90,12 +94,18 @@ final class MetricsRegistry {
         protoErrorCounter.onInvalidSeparator();
     }
 
+    // getters
+
     public long getAcceptedConnections() {
         return connectionCounter.connectionsAccepted.sum();
     }
 
     public long getClosedConnections() {
         return connectionCounter.connectionsClosed.sum();
+    }
+
+    public long getRefusedConnections() {
+        return connectionCounter.connectionRefused.sum();
     }
 
     public long getCurrentClients() {
@@ -212,6 +222,7 @@ final class MetricsRegistry {
         private final AtomicLong clientsCurrent = new AtomicLong(0);
         private final LongAdder connectionsAccepted = new LongAdder();
         private final LongAdder connectionsClosed = new LongAdder();
+        private final LongAdder connectionRefused = new LongAdder();
 
         private void onAccepted() {
             connectionsAccepted.increment();
@@ -226,6 +237,10 @@ final class MetricsRegistry {
                     + ", reset to 0");
                 clientsCurrent.set(0);
             }
+        }
+
+        private void onRefused() {
+            connectionRefused.increment();
         }
     }
 

--- a/src/main/java/com/kiwi/observability/ObservabilityRequestHandler.java
+++ b/src/main/java/com/kiwi/observability/ObservabilityRequestHandler.java
@@ -13,6 +13,7 @@ public class ObservabilityRequestHandler {
         return new MetricsDataDto(
             metricsRegistry.getAcceptedConnections(),
             metricsRegistry.getClosedConnections(),
+            metricsRegistry.getRefusedConnections(),
             metricsRegistry.getCurrentClients(),
             metricsRegistry.getBytesIn(),
             metricsRegistry.getBytesOut(),

--- a/src/main/java/com/kiwi/observability/RequestMetrics.java
+++ b/src/main/java/com/kiwi/observability/RequestMetrics.java
@@ -36,4 +36,12 @@ public final class RequestMetrics {
             case INVALID_SEPARATOR -> metricsRegistry.addInvalidSeparatorError();
         }
     }
+
+    public void onRefuse() {
+        metricsRegistry.addRefusedConnection();
+    }
+
+    public long getCurrentClients() {
+        return metricsRegistry.getCurrentClients();
+    }
 }

--- a/src/main/java/com/kiwi/observability/dto/MetricsDataDto.java
+++ b/src/main/java/com/kiwi/observability/dto/MetricsDataDto.java
@@ -3,6 +3,7 @@ package com.kiwi.observability.dto;
 public record MetricsDataDto(
     long acceptedConnections,
     long closedConnections,
+    long refusedConnections,
     long currentClients,
     long bytesIn,
     long bytesOut,

--- a/src/main/java/com/kiwi/server/TCPServer.java
+++ b/src/main/java/com/kiwi/server/TCPServer.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.net.ServerSocket;
 
 public class TCPServer {
+    //TODO will be moved to properties in phase 5
     private static final int SOCKET_PORT = 8090;
 
     private final RequestHandler requestHandler;

--- a/src/main/java/com/kiwi/server/response/ObservabilityResponse.java
+++ b/src/main/java/com/kiwi/server/response/ObservabilityResponse.java
@@ -13,6 +13,8 @@ public record ObservabilityResponse(
             metrics.acceptedConnections() +
             ", \"con.closed\": " +
             metrics.closedConnections() +
+            ", \"con.refused\": " +
+            metrics.refusedConnections() +
             ", \"con.current\": " +
             metrics.currentClients() +
             ", \"bytes.in\": " +


### PR DESCRIPTION
PR: Add maxClients gate and connectionsRefused counter

Description:
Introduce admission control: immediately refuse newly accepted sockets when currentClients ≥ maxClients. Increment connectionsRefused; do not bump acceptedConnections/currentClients on refusals. Default behavior is silent close (no banner, SO_LINGER off).

Notes:
Single-threaded, blocking accept loop limits validation paths; verified logic by setting maxClients=0 (all incoming connections refused as expected). Existing metrics and INF schema unchanged except for added connectionsRefused.
