### PR TITLE
develop/metrics -> add protocol versions

### DIFF
--- a/src/main/java/com/kiwi/config/properties/ProtocolProperties.java
+++ b/src/main/java/com/kiwi/config/properties/ProtocolProperties.java
@@ -1,0 +1,7 @@
+package com.kiwi.config.properties;
+
+//TODO all properties from this class will be moved to properties file in phase 5
+public class ProtocolProperties {
+    public static final String PROTOCOL_VERSION = "1.0";
+    public static final String INFO_SCHEMA_VERSION = "1.0";
+}

--- a/src/main/java/com/kiwi/observability/ObservabilityRequestHandler.java
+++ b/src/main/java/com/kiwi/observability/ObservabilityRequestHandler.java
@@ -1,5 +1,6 @@
 package com.kiwi.observability;
 
+import com.kiwi.config.properties.ProtocolProperties;
 import com.kiwi.observability.dto.MetricsDataDto;
 
 public class ObservabilityRequestHandler {
@@ -11,6 +12,8 @@ public class ObservabilityRequestHandler {
 
     public MetricsDataDto getMetricsInfo() {
         return new MetricsDataDto(
+            ProtocolProperties.PROTOCOL_VERSION,
+            ProtocolProperties.INFO_SCHEMA_VERSION,
             metricsRegistry.getAcceptedConnections(),
             metricsRegistry.getClosedConnections(),
             metricsRegistry.getRefusedConnections(),

--- a/src/main/java/com/kiwi/observability/dto/MetricsDataDto.java
+++ b/src/main/java/com/kiwi/observability/dto/MetricsDataDto.java
@@ -1,6 +1,8 @@
 package com.kiwi.observability.dto;
 
 public record MetricsDataDto(
+    String protocolVersion,
+    String infoSchemaVersion,
     long acceptedConnections,
     long closedConnections,
     long refusedConnections,

--- a/src/main/java/com/kiwi/server/response/ObservabilityResponse.java
+++ b/src/main/java/com/kiwi/server/response/ObservabilityResponse.java
@@ -33,6 +33,10 @@ public record ObservabilityResponse(
             metrics.infoRequests() +
             ", \"cmd.ping\": " +
             metrics.pingRequests() +
+            ", \"proto.version\": " +
+            metrics.protocolVersion() +
+            ", \"proto.infoschemaversion\": " +
+            metrics.infoSchemaVersion() +
             ", \"proto.err.unknown\": " +
             metrics.unknownMethod() +
             ", \"proto.err.headerlen\": " +


### PR DESCRIPTION
PR: Add protocolVersion and infoSchemaVersion to INF

Description:
Expose two version strings in INF: protocolVersion (wire framing; now “1.0” for length-prefixed method) and infoSchemaVersion (INF payload schema; “1.0”). No behavior change to commands or metrics.

Scope:
Define constants at bootstrap and include both fields in INF output.

Why:
Allows clients and tooling to verify compatibility and safely evolve framing or INF fields in future without ambiguity.
