### PR TITLE
develop/phase-2/ttl -> add expiration time

### DIFF
--- a/src/main/java/com/kiwi/dto/DataRequest.java
+++ b/src/main/java/com/kiwi/dto/DataRequest.java
@@ -1,10 +1,10 @@
 package com.kiwi.dto;
 
-import com.kiwi.persistent.dto.Key;
-import com.kiwi.persistent.dto.Value;
-
 public record DataRequest(
-    Key key,
-    Value data
+    byte[] key,
+    byte[] value
 ) {
+    public DataRequest(byte[] key) {
+        this(key, null);
+    }
 }

--- a/src/main/java/com/kiwi/persistent/Storage.java
+++ b/src/main/java/com/kiwi/persistent/Storage.java
@@ -1,24 +1,24 @@
 package com.kiwi.persistent;
 
-import com.kiwi.dto.DataRequest;
-import com.kiwi.persistent.dto.Key;
-import com.kiwi.persistent.dto.Value;
+import com.kiwi.persistent.dto.StorageRequest;
+import com.kiwi.persistent.model.Key;
+import com.kiwi.persistent.model.Value;
 import java.util.HashMap;
 import java.util.Map;
 
 public class Storage {
     private final Map<Key, Value> inMemoryStorage = new HashMap<>();
 
-    public void save(DataRequest request) {
-        inMemoryStorage.put(request.key(), request.data());
+    public void save(StorageRequest request) {
+        inMemoryStorage.put(request.key(), request.value());
     }
 
-    public Value getData(Key key) {
+    public Value getData(StorageRequest request) {
         //TODO null check?
-        return inMemoryStorage.get(key);
+        return inMemoryStorage.get(request.key());
     }
 
-    public void delete(Key key) {
-        inMemoryStorage.remove(key);
+    public void delete(StorageRequest request) {
+        inMemoryStorage.remove(request.key());
     }
 }

--- a/src/main/java/com/kiwi/persistent/dto/StorageRequest.java
+++ b/src/main/java/com/kiwi/persistent/dto/StorageRequest.java
@@ -1,0 +1,13 @@
+package com.kiwi.persistent.dto;
+
+import com.kiwi.persistent.model.Key;
+import com.kiwi.persistent.model.Value;
+
+public record StorageRequest(
+    Key key,
+    Value value
+) {
+    public StorageRequest(Key key) {
+        this(key, null);
+    }
+}

--- a/src/main/java/com/kiwi/persistent/model/Key.java
+++ b/src/main/java/com/kiwi/persistent/model/Key.java
@@ -1,4 +1,4 @@
-package com.kiwi.persistent.dto;
+package com.kiwi.persistent.model;
 
 import java.util.Arrays;
 

--- a/src/main/java/com/kiwi/persistent/model/Value.java
+++ b/src/main/java/com/kiwi/persistent/model/Value.java
@@ -1,16 +1,23 @@
-package com.kiwi.persistent.dto;
+package com.kiwi.persistent.model;
 
+import com.kiwi.persistent.model.expiration.ExpiryPolicy;
 import java.util.Arrays;
 
 public class Value {
     private final byte[] value;
+    private final ExpiryPolicy expiryPolicy;
 
-    public Value(byte[] value) {
+    public Value(byte[] value, ExpiryPolicy expiryPolicy) {
         this.value = value;
+        this.expiryPolicy = expiryPolicy;
     }
 
     public byte[] getValue() {
         return value;
+    }
+
+    public ExpiryPolicy getExpiryPolicy() {
+        return expiryPolicy;
     }
 
     @Override

--- a/src/main/java/com/kiwi/persistent/model/expiration/ExpiryPolicy.java
+++ b/src/main/java/com/kiwi/persistent/model/expiration/ExpiryPolicy.java
@@ -1,0 +1,7 @@
+package com.kiwi.persistent.model.expiration;
+
+public interface ExpiryPolicy {
+    boolean shouldEvictOnRead(long currentTime);
+    long remainingTime(long currentTime);
+    boolean hasTtl();
+}

--- a/src/main/java/com/kiwi/persistent/model/expiration/HasTtlExpiration.java
+++ b/src/main/java/com/kiwi/persistent/model/expiration/HasTtlExpiration.java
@@ -1,0 +1,24 @@
+package com.kiwi.persistent.model.expiration;
+
+public class HasTtlExpiration implements ExpiryPolicy {
+    private final long expirationTime;
+
+    public HasTtlExpiration(long expirationTime) {
+        this.expirationTime = expirationTime;
+    }
+
+    @Override
+    public boolean shouldEvictOnRead(long currentTime) {
+        return expirationTime - currentTime <= 0;
+    }
+
+    @Override
+    public long remainingTime(long currentTime) {
+        return expirationTime - currentTime;
+    }
+
+    @Override
+    public boolean hasTtl() {
+        return true;
+    }
+}

--- a/src/main/java/com/kiwi/persistent/model/expiration/NoOpExpiration.java
+++ b/src/main/java/com/kiwi/persistent/model/expiration/NoOpExpiration.java
@@ -1,0 +1,24 @@
+package com.kiwi.persistent.model.expiration;
+
+public class NoOpExpiration implements ExpiryPolicy {
+    private static final ExpiryPolicy instance = new NoOpExpiration();
+
+    public static ExpiryPolicy getInstance() {
+        return instance;
+    }
+
+    @Override
+    public boolean shouldEvictOnRead(long currentTime) {
+        return false;
+    }
+
+    @Override
+    public long remainingTime(long currentTime) {
+        return -1;
+    }
+
+    @Override
+    public boolean hasTtl() {
+        return false;
+    }
+}

--- a/src/main/java/com/kiwi/processor/DataProcessor.java
+++ b/src/main/java/com/kiwi/processor/DataProcessor.java
@@ -2,8 +2,10 @@ package com.kiwi.processor;
 
 import com.kiwi.dto.DataRequest;
 import com.kiwi.persistent.Storage;
-import com.kiwi.persistent.dto.Key;
-import com.kiwi.persistent.dto.Value;
+import com.kiwi.persistent.dto.StorageRequest;
+import com.kiwi.persistent.model.Key;
+import com.kiwi.persistent.model.Value;
+import com.kiwi.persistent.model.expiration.NoOpExpiration;
 
 public class DataProcessor {
     private final Storage storage;
@@ -12,15 +14,23 @@ public class DataProcessor {
         this.storage = storage;
     }
 
-    public void processData(DataRequest request) {
-        storage.save(request);
+    public void setData(DataRequest request) {
+        final var key = new Key(request.key());
+        final var value = new Value(request.value(), NoOpExpiration.getInstance());
+
+        storage.save(new StorageRequest(key, value));
     }
 
-    public Value getValue(Key key) {
-        return storage.getData(key);
+    public Value getValue(DataRequest request) {
+        final var storageRequest = new StorageRequest(new Key(request.key()));
+        final var value = storage.getData(storageRequest);
+        if (value.getExpiryPolicy().shouldEvictOnRead(System.currentTimeMillis())) {
+            storage.delete(storageRequest);
+        }
+        return value;
     }
 
-    public void deleteValue(Key key) {
-        storage.delete(key);
+    public void deleteValue(DataRequest request) {
+        storage.delete(new StorageRequest(new Key(request.key())));
     }
 }

--- a/src/main/java/com/kiwi/server/RequestDispatcher.java
+++ b/src/main/java/com/kiwi/server/RequestDispatcher.java
@@ -31,16 +31,21 @@ public class RequestDispatcher {
             case GET -> {
                 metrics.onGet();
                 yield new TCPResponse(
-                    new DataResponse(dataProcessor.getValue(request.key())), OK_MESSAGE, true);
+                    new DataResponse(
+                        dataProcessor.getValue(
+                            new DataRequest(request.key())
+                        )
+                    ), OK_MESSAGE, true
+                );
             }
             case SET -> {
                 metrics.onSet();
-                dataProcessor.processData(new DataRequest(request.key(), request.value()));
+                dataProcessor.setData(new DataRequest(request.key(), request.value()));
                 yield new TCPResponse(OK_MESSAGE);
             }
             case DEL -> {
                 metrics.onDelete();
-                dataProcessor.deleteValue(request.key());
+                dataProcessor.deleteValue(new DataRequest(request.key()));
                 yield new TCPResponse(OK_MESSAGE);
             }
             case EXT -> {

--- a/src/main/java/com/kiwi/server/RequestParser.java
+++ b/src/main/java/com/kiwi/server/RequestParser.java
@@ -13,8 +13,6 @@ import static com.kiwi.server.util.ServerConstants.SEPARATOR;
 
 import com.kiwi.server.dto.TCPRequest;
 import com.kiwi.exception.protocol.ProtocolException;
-import com.kiwi.persistent.dto.Key;
-import com.kiwi.persistent.dto.Value;
 import java.nio.charset.StandardCharsets;
 import java.util.logging.Logger;
 
@@ -43,7 +41,7 @@ public class RequestParser {
         }
     }
 
-    private Value getValue(InputStreamWrapper is) {
+    private byte[] getValue(InputStreamWrapper is) {
         final int valueLen = getLength(is, MAX_HEADER_VAL_LEN);
         if (valueLen > MAX_VAL_LEN) {
             log.severe("Value length bigger than allowed 10MB: " + valueLen);
@@ -51,10 +49,10 @@ public class RequestParser {
                 VALUE_TOO_LONG);
         }
 
-        return new Value(getBytesByLength(is, valueLen));
+        return getBytesByLength(is, valueLen);
     }
 
-    private Key getKey(InputStreamWrapper is) {
+    private byte[] getKey(InputStreamWrapper is) {
         final int keyLen = getLength(is, MAX_HEADER_KEY_LENGTH);
         if (keyLen > MAX_KEY_LENGTH) {
             log.severe("Key length bigger than allowed 4KB: " + keyLen);
@@ -62,7 +60,7 @@ public class RequestParser {
                 KEY_TOO_LONG);
         }
 
-        return new Key(getBytesByLength(is, keyLen));
+        return getBytesByLength(is, keyLen);
     }
 
     private byte[] getBytesByLength(InputStreamWrapper is, int length) {

--- a/src/main/java/com/kiwi/server/dto/TCPRequest.java
+++ b/src/main/java/com/kiwi/server/dto/TCPRequest.java
@@ -1,19 +1,17 @@
 package com.kiwi.server.dto;
 
-import com.kiwi.persistent.dto.Key;
-import com.kiwi.persistent.dto.Value;
 import com.kiwi.server.Method;
 
 public record TCPRequest(
     Method method,
-    Key key,
-    Value value
+    byte[] key,
+    byte[] value
 ) {
-    public TCPRequest(Method method, Key key) {
+    public TCPRequest(Method method, byte[] key) {
         this(method, key, null);
     }
 
     public TCPRequest(Method method) {
-        this(method, null);
+        this(method, null, null);
     }
 }

--- a/src/main/java/com/kiwi/server/response/DataResponse.java
+++ b/src/main/java/com/kiwi/server/response/DataResponse.java
@@ -1,6 +1,6 @@
 package com.kiwi.server.response;
 
-import com.kiwi.persistent.dto.Value;
+import com.kiwi.persistent.model.Value;
 
 public record DataResponse(
     Value value


### PR DESCRIPTION


**Title:** Storage/Parser: introduce ExpiryPolicy (NoOp/HasTtl) and move domain object creation to DataProcessor

**Summary:**
Add `ExpiryPolicy` with `NoOpExpiration` (no TTL) and `HasTtlExpiration` (expiry at millis). Refactor request flow so the parser returns `TCPRequest` with raw `byte[] key` and `byte[] value`. The `DataProcessor` now constructs `Key`, `Value`, and attaches the appropriate `ExpiryPolicy` before handing off to `Storage` (`Map<Key, Value>`). No behavior changes to commands or protocol.

**Why:**

* Preserve clean layering: parser handles bytes; domain assembly and TTL policy stay server-side.
* Prevents protocol layer from depending on TTL classes.
* Preps for Phase-2 lazy-expiry gate without touching the wire.

**Changes (scope):**

* New interface `ExpiryPolicy { shouldEvictOnRead(now), remainingTime(now), hasTtl() }`.
* Implementations: `NoOpExpiration` (singleton), `HasTtlExpiration(expireAtMillis)`.
* Parser now outputs `TCPRequest` with raw bytes only.
* `DataProcessor` builds `Key`, `Value`, and selects policy (`NoOpExpiration` for PR-1).
* `Storage` continues to manage `Map<Key, Value>` unchanged.

**Non-goals (for this PR):**

* No lazy-expiry execution yet (comes next).
* No new commands or INFO fields.

**Acceptance checks:**

* All existing commands behave identically.
* New classes wired; parser has no dependency on TTL classes.
* Default for new entries uses `NoOpExpiration` (no TTL).
