### PR TITLE
Develop/phase 2/eviction in storage

### DIFF
--- a/src/main/java/com/kiwi/observability/MetricsRegistry.java
+++ b/src/main/java/com/kiwi/observability/MetricsRegistry.java
@@ -14,6 +14,7 @@ final class MetricsRegistry {
     private final MethodCounter methodCounter = new MethodCounter();
     private final ProtoErrorCounter protoErrorCounter = new ProtoErrorCounter();
     private final ServerCounters serverCounters = new ServerCounters();
+    private final StorageCounter storageCounter = new StorageCounter();
 
     public static MetricsRegistry getInstance() {
         return instance;
@@ -98,6 +99,10 @@ final class MetricsRegistry {
         protoErrorCounter.onMethodTooLong();
     }
 
+    public void addTtlExpiredEviction() {
+        storageCounter.onTtlExpiredEviction();
+    }
+
     // getters
 
     public long getAcceptedConnections() {
@@ -179,6 +184,12 @@ final class MetricsRegistry {
     public long getServerStart() {
         return serverCounters.startUpMillis;
     }
+
+    public long getTtlExpiredEviction() {
+        return storageCounter.ttlExpiredEvictions.sum();
+    }
+
+    // private classes
 
     private static class MethodCounter {
         private final LongAdder getCounter = new LongAdder();
@@ -297,5 +308,13 @@ final class MetricsRegistry {
 
     private static class ServerCounters {
         private final long startUpMillis = System.currentTimeMillis();
+    }
+
+    private static class StorageCounter {
+        private final LongAdder ttlExpiredEvictions = new LongAdder();
+
+        private void onTtlExpiredEviction() {
+            ttlExpiredEvictions.increment();
+        }
     }
 }

--- a/src/main/java/com/kiwi/observability/ObservabilityModule.java
+++ b/src/main/java/com/kiwi/observability/ObservabilityModule.java
@@ -13,4 +13,8 @@ public class ObservabilityModule {
     public static MethodMetrics getMethodMetrics() {
         return new MethodMetrics(MetricsRegistry.getInstance());
     }
+
+    public static StorageMetrics getStorageMetrics() {
+        return new StorageMetrics(MetricsRegistry.getInstance());
+    }
 }

--- a/src/main/java/com/kiwi/observability/ObservabilityRequestHandler.java
+++ b/src/main/java/com/kiwi/observability/ObservabilityRequestHandler.java
@@ -34,7 +34,8 @@ public class ObservabilityRequestHandler {
             metricsRegistry.getNonDigitInLength(),
             metricsRegistry.getInvalidSeparator(),
             metricsRegistry.getServerStart(),
-            System.currentTimeMillis() - metricsRegistry.getServerStart()
+            System.currentTimeMillis() - metricsRegistry.getServerStart(),
+            metricsRegistry.getTtlExpiredEviction()
         );
     }
 }

--- a/src/main/java/com/kiwi/observability/StorageMetrics.java
+++ b/src/main/java/com/kiwi/observability/StorageMetrics.java
@@ -1,0 +1,14 @@
+package com.kiwi.observability;
+
+public class StorageMetrics {
+    private final MetricsRegistry metricsRegistry;
+
+    public StorageMetrics(MetricsRegistry metricsRegistry) {
+        this.metricsRegistry = metricsRegistry;
+    }
+
+    public void onTtlExpiredEviction() {
+        metricsRegistry.addTtlExpiredEviction();
+    }
+
+}

--- a/src/main/java/com/kiwi/observability/dto/MetricsDataDto.java
+++ b/src/main/java/com/kiwi/observability/dto/MetricsDataDto.java
@@ -23,6 +23,7 @@ public record MetricsDataDto(
     long nonDigitInLength,
     long invalidSeparator,
     long serverStart,
-    long serverUptime
+    long serverUptime,
+    long ttlExpiredEviction
 ) {
 }

--- a/src/main/java/com/kiwi/persistent/PersistentModule.java
+++ b/src/main/java/com/kiwi/persistent/PersistentModule.java
@@ -1,12 +1,11 @@
 package com.kiwi.persistent;
 
-import java.util.HashMap;
-import java.util.Map;
+import com.kiwi.observability.ObservabilityModule;
 
 public class PersistentModule {
 
     public static Storage create() {
-        return new Storage();
+        return new Storage(ObservabilityModule.getStorageMetrics());
     }
 
 }

--- a/src/main/java/com/kiwi/persistent/Storage.java
+++ b/src/main/java/com/kiwi/persistent/Storage.java
@@ -1,5 +1,6 @@
 package com.kiwi.persistent;
 
+import com.kiwi.observability.StorageMetrics;
 import com.kiwi.persistent.dto.StorageRequest;
 import com.kiwi.persistent.model.Key;
 import com.kiwi.persistent.model.Value;
@@ -9,16 +10,34 @@ import java.util.Map;
 public class Storage {
     private final Map<Key, Value> inMemoryStorage = new HashMap<>();
 
+    private final StorageMetrics storageMetrics;
+
+    public Storage(StorageMetrics storageMetrics) {
+        this.storageMetrics = storageMetrics;
+    }
+
     public void save(StorageRequest request) {
         inMemoryStorage.put(request.key(), request.value());
     }
 
     public Value getData(StorageRequest request) {
-        //TODO null check?
-        return inMemoryStorage.get(request.key());
+        final var value = inMemoryStorage.get(request.key());
+
+        if (value == null || value.getExpiryPolicy().shouldEvictOnRead(System.currentTimeMillis())) {
+            inMemoryStorage.remove(request.key());
+            storageMetrics.onTtlExpiredEviction();
+            return new Value(new byte[0]);
+        } else {
+            return value;
+        }
     }
 
     public void delete(StorageRequest request) {
+        final var value = inMemoryStorage.get(request.key());
+        // TODO will be implemented later with permanent storage lookup only for headers
+        if (value != null && value.getExpiryPolicy().shouldEvictOnRead(System.currentTimeMillis())) {
+            storageMetrics.onTtlExpiredEviction();
+        }
         inMemoryStorage.remove(request.key());
     }
 }

--- a/src/main/java/com/kiwi/persistent/model/Value.java
+++ b/src/main/java/com/kiwi/persistent/model/Value.java
@@ -7,6 +7,10 @@ public class Value {
     private final byte[] value;
     private final ExpiryPolicy expiryPolicy;
 
+    public Value(byte[] value) {
+        this(value, null);
+    }
+
     public Value(byte[] value, ExpiryPolicy expiryPolicy) {
         this.value = value;
         this.expiryPolicy = expiryPolicy;

--- a/src/main/java/com/kiwi/processor/DataProcessor.java
+++ b/src/main/java/com/kiwi/processor/DataProcessor.java
@@ -22,12 +22,7 @@ public class DataProcessor {
     }
 
     public Value getValue(DataRequest request) {
-        final var storageRequest = new StorageRequest(new Key(request.key()));
-        final var value = storage.getData(storageRequest);
-        if (value != null && value.getExpiryPolicy().shouldEvictOnRead(System.currentTimeMillis())) {
-            storage.delete(storageRequest);
-        }
-        return value;
+        return storage.getData(new StorageRequest(new Key(request.key())));
     }
 
     public void deleteValue(DataRequest request) {

--- a/src/main/java/com/kiwi/server/response/DataResponse.java
+++ b/src/main/java/com/kiwi/server/response/DataResponse.java
@@ -8,7 +8,6 @@ public record DataResponse(
 
     @Override
     public byte[] serialize() {
-        //TODO clarify on absent value
-        return value == null ? new byte[0] : value.getValue();
+        return value.getValue();
     }
 }

--- a/src/main/java/com/kiwi/server/response/ObservabilityResponse.java
+++ b/src/main/java/com/kiwi/server/response/ObservabilityResponse.java
@@ -55,6 +55,8 @@ public record ObservabilityResponse(
             metrics.serverStart() +
             ", \"server.uptime\": " +
             metrics.serverUptime() +
+            ", \"storage.ttl.expired.eviction\": " +
+            metrics.ttlExpiredEviction() +
             " }")
             .getBytes(StandardCharsets.UTF_8);
     }


### PR DESCRIPTION
**Title:** TTL: move lazy-expiry gate to Storage, add metrics (+ INFO fields), unify DEL semantics

**Summary:**

* Centralize lazy-expiry in **Storage**: on read/existence paths, if `shouldEvictOnRead(now)` → remove entry and return “absent.”
* **GET** now returns “missing” for expired keys; **DEL** first applies the same gate so expired keys yield `0`.
* Add storage-side counter **`ttl_lazy_expired_evictions`**; increment only when a TTL-driven removal happens in the gate.
* Extend **INFO** (additive only) to expose the new TTL metric(s). No renames of existing v1.0 fields.   

**Why:**
One choke point prevents missed paths and double lookups; aligns with Phase-2 goals for uniform lazy expiry and observable TTL behavior, with INFO remaining backward-compatible. 

**Scope:**

* Storage: single-lookup gate (read/existence) + metric bump on TTL-driven deletes.
* Dispatcher/DataProcessor: route **GET** and **DEL** through the gate.
* INFO: include `ttl_lazy_expired_evictions` (and any delete metric you added) as new fields; existing names untouched. 

**Non-goals:**
No new commands yet (`EXPIRE/PEXPIRE/PERSIST/TTL/PTTL` come next). No protocol changes. 

**Acceptance:**

* Expired key on **GET** → missing; counter +1.
* **DEL** on expired key → 0; counter +1 once (from the gate).
* **INFO** shows the new TTL metric(s); prior fields unchanged. 
