### PR TITLE
develop/phase-5/config domain + refactoring

### DIFF
--- a/docs/notes.txt
+++ b/docs/notes.txt
@@ -1,7 +1,2 @@
-AFTER PHASE 4:
+AFTER PHASE 5:
     - test socket with different options (buffer size, latency, bandwidth)
-    - extract common util for parsing ascii long from byte array
-    - implement lock stripping on storage (initial 16 locks, each lock for key computed by hash)
-      resize locks (think about max amount), one common lock mechanism for resize locks operation
-      OR think about mutex for each key, based on some marker is key currently in use (if possible implement without
-      spin lock)

--- a/src/main/java/com/kiwi/concurrency/KiwiThreadPool.java
+++ b/src/main/java/com/kiwi/concurrency/KiwiThreadPool.java
@@ -1,7 +1,7 @@
 package com.kiwi.concurrency;
 
 import com.kiwi.concurrency.exception.KiwiGeneralException;
-import com.kiwi.observability.ThreadPoolMetrics;
+import com.kiwi.observability.metrics.ThreadPoolMetrics;
 
 import java.util.Map;
 import java.util.concurrent.*;

--- a/src/main/java/com/kiwi/concurrency/KiwiThreadPoolExecutor.java
+++ b/src/main/java/com/kiwi/concurrency/KiwiThreadPoolExecutor.java
@@ -1,7 +1,7 @@
 package com.kiwi.concurrency;
 
 import com.kiwi.concurrency.task.Task;
-import com.kiwi.observability.ThreadPoolMetrics;
+import com.kiwi.observability.metrics.ThreadPoolMetrics;
 
 import java.util.concurrent.ThreadFactory;
 import java.util.logging.Logger;

--- a/src/main/java/com/kiwi/concurrency/factory/ConcurrencyModule.java
+++ b/src/main/java/com/kiwi/concurrency/factory/ConcurrencyModule.java
@@ -4,7 +4,7 @@ import com.kiwi.concurrency.KiwiThreadFactory;
 import com.kiwi.concurrency.KiwiThreadPool;
 import com.kiwi.concurrency.KiwiThreadPoolExecutor;
 import com.kiwi.observability.factory.ObservabilityContainer;
-import com.kiwi.observability.ThreadPoolMetrics;
+import com.kiwi.observability.metrics.ThreadPoolMetrics;
 
 import java.util.Map;
 

--- a/src/main/java/com/kiwi/config/ConfigModule.java
+++ b/src/main/java/com/kiwi/config/ConfigModule.java
@@ -1,0 +1,11 @@
+package com.kiwi.config;
+
+import com.kiwi.config.builder.ConfigBuilder;
+import com.kiwi.config.domain.Config;
+
+public class ConfigModule {
+    public static Config createConfig() {
+        final var builder = new ConfigBuilder();
+        return builder.build();
+    }
+}

--- a/src/main/java/com/kiwi/config/builder/ConfigBuilder.java
+++ b/src/main/java/com/kiwi/config/builder/ConfigBuilder.java
@@ -1,0 +1,62 @@
+package com.kiwi.config.builder;
+
+import com.kiwi.config.domain.Config;
+import com.kiwi.exception.ConfigurationValidationException;
+
+import static com.kiwi.config.properties.DefaultProperties.BACKLOG;
+import static com.kiwi.config.properties.DefaultProperties.MAX_CLIENTS;
+import static com.kiwi.config.properties.DefaultProperties.METRICS_ENABLED;
+import static com.kiwi.config.properties.DefaultProperties.SERVER_PORT;
+import static com.kiwi.config.properties.DefaultProperties.TIMEOUT_MILLIS;
+
+public class ConfigBuilder {
+    private int port = SERVER_PORT;
+    private int backlog = BACKLOG;
+    private int maxClients = MAX_CLIENTS;
+    private int soTimeoutMillis = TIMEOUT_MILLIS;
+    private boolean metricsEnabled = METRICS_ENABLED;
+
+    public ConfigBuilder() {}
+
+    public ConfigBuilder port(int port) {
+        this.port = port;
+        return this;
+    }
+
+    public ConfigBuilder backlog(int backlog) {
+        this.backlog = backlog;
+        return this;
+    }
+
+    public ConfigBuilder maxClients(int maxClients) {
+        this.maxClients = maxClients;
+        return this;
+    }
+
+    public ConfigBuilder soTimeoutMillis(int soTimeoutMillis) {
+        this.soTimeoutMillis = soTimeoutMillis;
+        return this;
+    }
+
+    public ConfigBuilder metricsEnabled(boolean metricsEnabled) {
+        this.metricsEnabled = metricsEnabled;
+        return this;
+    }
+
+    public Config build() {
+        if (port < 0 || port > 65535) {
+            throw new ConfigurationValidationException("Invalid port number: " + port);
+        }
+        if (backlog < 0) {
+            throw new ConfigurationValidationException("Invalid backlog number: " + backlog);
+        }
+        if (maxClients <= 0) {
+            throw new ConfigurationValidationException("Invalid max clients number: " + maxClients);
+        }
+        if (soTimeoutMillis < 0) {
+            throw new ConfigurationValidationException("Invalid timeout number: " + soTimeoutMillis);
+        }
+
+        return new Config(this.port, this.backlog, this.maxClients, this.soTimeoutMillis, this.metricsEnabled);
+    }
+}

--- a/src/main/java/com/kiwi/config/builder/ConfigBuilder.java
+++ b/src/main/java/com/kiwi/config/builder/ConfigBuilder.java
@@ -1,7 +1,7 @@
 package com.kiwi.config.builder;
 
 import com.kiwi.config.domain.Config;
-import com.kiwi.exception.ConfigurationValidationException;
+import com.kiwi.exception.config.ConfigurationValidationException;
 
 import static com.kiwi.config.properties.DefaultProperties.BACKLOG;
 import static com.kiwi.config.properties.DefaultProperties.MAX_CLIENTS;
@@ -44,7 +44,7 @@ public class ConfigBuilder {
     }
 
     public Config build() {
-        if (port < 0 || port > 65535) {
+        if (port <= 0 || port > 65535) {
             throw new ConfigurationValidationException("Invalid port number: " + port);
         }
         if (backlog < 0) {

--- a/src/main/java/com/kiwi/config/domain/Config.java
+++ b/src/main/java/com/kiwi/config/domain/Config.java
@@ -1,0 +1,10 @@
+package com.kiwi.config.domain;
+
+public record Config(
+        int port,
+        int backlog,
+        int maxClients,
+        int soTimeoutMillis,
+        boolean metricsEnabled
+) {
+}

--- a/src/main/java/com/kiwi/config/properties/DefaultProperties.java
+++ b/src/main/java/com/kiwi/config/properties/DefaultProperties.java
@@ -1,0 +1,11 @@
+package com.kiwi.config.properties;
+
+public final class DefaultProperties {
+    public static final int SERVER_PORT = 8090;
+    public static final int BACKLOG = 128;
+    public static final int MAX_CLIENTS = 1000;
+    public static final int TIMEOUT_MILLIS = 0;
+    public static final boolean METRICS_ENABLED = true;
+
+    private DefaultProperties() {}
+}

--- a/src/main/java/com/kiwi/exception/ConfigurationValidationException.java
+++ b/src/main/java/com/kiwi/exception/ConfigurationValidationException.java
@@ -1,0 +1,7 @@
+package com.kiwi.exception;
+
+public class ConfigurationValidationException extends RuntimeException {
+    public ConfigurationValidationException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/kiwi/exception/config/ConfigurationValidationException.java
+++ b/src/main/java/com/kiwi/exception/config/ConfigurationValidationException.java
@@ -1,4 +1,4 @@
-package com.kiwi.exception;
+package com.kiwi.exception.config;
 
 public class ConfigurationValidationException extends RuntimeException {
     public ConfigurationValidationException(String message) {

--- a/src/main/java/com/kiwi/observability/factory/ObservabilityContainer.java
+++ b/src/main/java/com/kiwi/observability/factory/ObservabilityContainer.java
@@ -1,11 +1,11 @@
 package com.kiwi.observability.factory;
 
-import com.kiwi.observability.MethodMetrics;
+import com.kiwi.observability.metrics.MethodMetrics;
 import com.kiwi.observability.MetricsProvider;
-import com.kiwi.observability.OperationErrorMetrics;
-import com.kiwi.observability.RequestMetrics;
-import com.kiwi.observability.StorageMetrics;
-import com.kiwi.observability.ThreadPoolMetrics;
+import com.kiwi.observability.metrics.OperationErrorMetrics;
+import com.kiwi.observability.metrics.RequestMetrics;
+import com.kiwi.observability.metrics.StorageMetrics;
+import com.kiwi.observability.metrics.ThreadPoolMetrics;
 
 import java.util.Map;
 

--- a/src/main/java/com/kiwi/observability/factory/ObservabilityModule.java
+++ b/src/main/java/com/kiwi/observability/factory/ObservabilityModule.java
@@ -1,12 +1,12 @@
 package com.kiwi.observability.factory;
 
-import com.kiwi.observability.MethodMetrics;
+import com.kiwi.observability.metrics.MethodMetrics;
 import com.kiwi.observability.MetricsProvider;
 import com.kiwi.observability.MetricsRegistry;
-import com.kiwi.observability.OperationErrorMetrics;
-import com.kiwi.observability.RequestMetrics;
-import com.kiwi.observability.StorageMetrics;
-import com.kiwi.observability.ThreadPoolMetrics;
+import com.kiwi.observability.metrics.OperationErrorMetrics;
+import com.kiwi.observability.metrics.RequestMetrics;
+import com.kiwi.observability.metrics.StorageMetrics;
+import com.kiwi.observability.metrics.ThreadPoolMetrics;
 
 import java.util.Map;
 

--- a/src/main/java/com/kiwi/observability/metrics/MethodMetrics.java
+++ b/src/main/java/com/kiwi/observability/metrics/MethodMetrics.java
@@ -1,5 +1,6 @@
-package com.kiwi.observability;
+package com.kiwi.observability.metrics;
 
+import com.kiwi.observability.MetricsRegistry;
 import com.kiwi.server.request.Method;
 
 import static com.kiwi.observability.util.MetricKeys.CMD_DBSIZE;

--- a/src/main/java/com/kiwi/observability/metrics/OperationErrorMetrics.java
+++ b/src/main/java/com/kiwi/observability/metrics/OperationErrorMetrics.java
@@ -1,5 +1,6 @@
-package com.kiwi.observability;
+package com.kiwi.observability.metrics;
 
+import com.kiwi.observability.MetricsRegistry;
 import com.kiwi.persistent.mutation.ErrorType;
 
 import static com.kiwi.observability.util.MetricKeys.OP_NOT_EXISTS;

--- a/src/main/java/com/kiwi/observability/metrics/RequestMetrics.java
+++ b/src/main/java/com/kiwi/observability/metrics/RequestMetrics.java
@@ -1,6 +1,7 @@
-package com.kiwi.observability;
+package com.kiwi.observability.metrics;
 
 import com.kiwi.exception.protocol.ProtocolErrorCode;
+import com.kiwi.observability.MetricsRegistry;
 
 import static com.kiwi.observability.util.MetricKeys.BYTES_IN;
 import static com.kiwi.observability.util.MetricKeys.BYTES_OUT;

--- a/src/main/java/com/kiwi/observability/metrics/StorageMetrics.java
+++ b/src/main/java/com/kiwi/observability/metrics/StorageMetrics.java
@@ -1,4 +1,6 @@
-package com.kiwi.observability;
+package com.kiwi.observability.metrics;
+
+import com.kiwi.observability.MetricsRegistry;
 
 import static com.kiwi.observability.util.MetricKeys.STORAGE_TTL_EXPIRED_EVICTION;
 

--- a/src/main/java/com/kiwi/observability/metrics/ThreadPoolMetrics.java
+++ b/src/main/java/com/kiwi/observability/metrics/ThreadPoolMetrics.java
@@ -1,4 +1,6 @@
-package com.kiwi.observability;
+package com.kiwi.observability.metrics;
+
+import com.kiwi.observability.MetricsRegistry;
 
 import static com.kiwi.observability.util.MetricKeys.BP_PAUSED_COUNT;
 import static com.kiwi.observability.util.MetricKeys.BP_PAUSE_COUNT;

--- a/src/main/java/com/kiwi/persistent/storage/StorageStrippingLockImpl.java
+++ b/src/main/java/com/kiwi/persistent/storage/StorageStrippingLockImpl.java
@@ -1,6 +1,6 @@
 package com.kiwi.persistent.storage;
 
-import com.kiwi.observability.StorageMetrics;
+import com.kiwi.observability.metrics.StorageMetrics;
 import com.kiwi.persistent.model.Key;
 import com.kiwi.persistent.model.Value;
 import com.kiwi.persistent.mutation.CurrentState;

--- a/src/main/java/com/kiwi/server/accept/TCPServer.java
+++ b/src/main/java/com/kiwi/server/accept/TCPServer.java
@@ -1,6 +1,6 @@
 package com.kiwi.server.accept;
 
-import com.kiwi.observability.RequestMetrics;
+import com.kiwi.observability.metrics.RequestMetrics;
 import com.kiwi.server.backpressure.BackPressureGate;
 import com.kiwi.server.context.ConnectionContext;
 import com.kiwi.server.context.ConnectionRegistry;

--- a/src/main/java/com/kiwi/server/backpressure/BackPressureGate.java
+++ b/src/main/java/com/kiwi/server/backpressure/BackPressureGate.java
@@ -1,7 +1,7 @@
 package com.kiwi.server.backpressure;
 
 import com.kiwi.concurrency.KiwiThreadPoolExecutor;
-import com.kiwi.observability.ThreadPoolMetrics;
+import com.kiwi.observability.metrics.ThreadPoolMetrics;
 
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;

--- a/src/main/java/com/kiwi/server/dispatcher/RequestDispatcher.java
+++ b/src/main/java/com/kiwi/server/dispatcher/RequestDispatcher.java
@@ -24,9 +24,9 @@ import static com.kiwi.server.request.Method.TTL;
 import static com.kiwi.server.util.ServerConstants.ERROR_MESSAGE;
 import static com.kiwi.server.util.ServerConstants.OK_MESSAGE;
 
-import com.kiwi.observability.MethodMetrics;
+import com.kiwi.observability.metrics.MethodMetrics;
 import com.kiwi.observability.MetricsProvider;
-import com.kiwi.observability.OperationErrorMetrics;
+import com.kiwi.observability.metrics.OperationErrorMetrics;
 import com.kiwi.persistent.storage.Storage;
 import com.kiwi.server.dispatcher.command.DbSizeCommandHandler;
 import com.kiwi.server.dispatcher.command.DeleteCommandHandler;

--- a/src/main/java/com/kiwi/server/dispatcher/command/ExpireCommandHandler.java
+++ b/src/main/java/com/kiwi/server/dispatcher/command/ExpireCommandHandler.java
@@ -4,7 +4,7 @@ import static com.kiwi.persistent.mutation.ErrorType.NOT_EXISTS;
 import static com.kiwi.server.response.model.BinaryResponseValues.FAIL;
 import static com.kiwi.server.response.model.BinaryResponseValues.SUCCESS;
 
-import com.kiwi.observability.OperationErrorMetrics;
+import com.kiwi.observability.metrics.OperationErrorMetrics;
 import com.kiwi.persistent.storage.Storage;
 import com.kiwi.persistent.model.Key;
 import com.kiwi.persistent.model.Value;

--- a/src/main/java/com/kiwi/server/dispatcher/command/NumericOperationCommandHandler.java
+++ b/src/main/java/com/kiwi/server/dispatcher/command/NumericOperationCommandHandler.java
@@ -1,6 +1,6 @@
 package com.kiwi.server.dispatcher.command;
 
-import com.kiwi.observability.OperationErrorMetrics;
+import com.kiwi.observability.metrics.OperationErrorMetrics;
 import com.kiwi.persistent.storage.Storage;
 import com.kiwi.persistent.model.Key;
 import com.kiwi.persistent.model.Value;

--- a/src/main/java/com/kiwi/server/dispatcher/command/PersistCommandHandler.java
+++ b/src/main/java/com/kiwi/server/dispatcher/command/PersistCommandHandler.java
@@ -4,7 +4,7 @@ import static com.kiwi.persistent.mutation.ErrorType.NOT_EXISTS;
 import static com.kiwi.server.response.model.BinaryResponseValues.FAIL;
 import static com.kiwi.server.response.model.BinaryResponseValues.SUCCESS;
 
-import com.kiwi.observability.OperationErrorMetrics;
+import com.kiwi.observability.metrics.OperationErrorMetrics;
 import com.kiwi.persistent.storage.Storage;
 import com.kiwi.persistent.model.Key;
 import com.kiwi.persistent.model.Value;

--- a/src/main/java/com/kiwi/server/request/ConnectionReader.java
+++ b/src/main/java/com/kiwi/server/request/ConnectionReader.java
@@ -3,7 +3,7 @@ package com.kiwi.server.request;
 import com.kiwi.concurrency.KiwiThreadPoolExecutor;
 import com.kiwi.concurrency.task.ConnectionTask;
 import com.kiwi.exception.protocol.ProtocolException;
-import com.kiwi.observability.RequestMetrics;
+import com.kiwi.observability.metrics.RequestMetrics;
 import com.kiwi.server.buffer.Cursor;
 import com.kiwi.server.buffer.ReadBuffer;
 import com.kiwi.server.context.ConnectionContext;

--- a/src/main/java/com/kiwi/server/request/RequestHandler.java
+++ b/src/main/java/com/kiwi/server/request/RequestHandler.java
@@ -1,7 +1,7 @@
 package com.kiwi.server.request;
 
 import com.kiwi.exception.protocol.ProtocolException;
-import com.kiwi.observability.RequestMetrics;
+import com.kiwi.observability.metrics.RequestMetrics;
 import com.kiwi.server.context.ConnectionContext;
 import com.kiwi.server.dispatcher.RequestDispatcher;
 import com.kiwi.server.request.model.TCPRequest;

--- a/src/main/java/com/kiwi/server/response/WriterProxy.java
+++ b/src/main/java/com/kiwi/server/response/WriterProxy.java
@@ -1,6 +1,6 @@
 package com.kiwi.server.response;
 
-import com.kiwi.observability.RequestMetrics;
+import com.kiwi.observability.metrics.RequestMetrics;
 import com.kiwi.server.response.model.TCPResponse;
 
 import java.io.OutputStream;


### PR DESCRIPTION


## Phase 5 — PR 1: Immutable Config Model & Validation

### Summary

This PR introduces the **immutable configuration model** for Phase 5, including:

* centralized supported config keys (as constants)
* default values
* typed immutable `Config` snapshot
* validation with fail-fast behavior

No config sources (file/env/system) are implemented yet — this PR focuses strictly on the **config domain model**.

---

### Scope

**Included:**

* `Config` — immutable snapshot with typed fields:

  * `server.port`
  * `server.backlog`
  * `server.maxClients`
  * `socket.soTimeoutMillis`
  * `metrics.enabled`
* `ConfigBuilder`

  * initializes from defaults
  * allows overriding values
  * validates on `build()`
* Validation rules:

  * port must be within valid TCP range
  * backlog must be non-negative
  * `maxClients >= 1`
  * `soTimeoutMillis >= 0`
* `ConfigValidationException` (fail-fast on invalid config)

**Not included (intentionally deferred):**

* properties file loading
* environment variables
* JVM `-D` overrides
* config precedence
* server/bootstrap wiring
* `CONFIG GET` command
* `INFO` config section

---

### Design Notes

* Config is **immutable** and created once at bootstrap (no hot reload).
* Runtime code will use **typed fields**, not string-based lookups.
* Canonical config keys are currently defined as constants (no `ConfigKey` abstraction yet).
* Builder pattern is used to enforce:

  * controlled construction
  * centralized validation
  * future extensibility for layered config sources

---

### Rationale

This PR isolates the **core configuration model** before introducing:

* multiple config sources
* precedence rules
* admin surface (`CONFIG GET`, `INFO`)

Keeping this PR small ensures:

* clear validation boundaries
* stable foundation for next steps
* easier review

---

### Follow-ups (next PRs)

* Config source loading (file/env/system) with precedence:
  `-D` > env > file > defaults
* Wiring config into server bootstrap
* Structured logging with context
* Admin commands (`CONFIG GET`) and `INFO` extension

---

### Acceptance Criteria

* Config can be built from defaults only
* Overrides via builder work correctly
* Invalid values fail fast with clear errors
* Config object is fully immutable
* No runtime subsystem depends on config yet

---

If you want, next step we can review your actual `Config`/`Builder` design before moving to PR 2 — that’s where most subtle mistakes usually happen.
